### PR TITLE
switch off moment.js to date-fns-tz for logging

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -13,8 +13,7 @@
 var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
-var {format, formatInTimeZone} = require('date-fns-tz');
-var { endOfDay } = require('date-fns');
+const { format, formatInTimeZone } = require('date-fns-tz');
 
 var EventEmitter = require('events');
 
@@ -461,7 +460,7 @@ FileStreamRotator.getStream = function (options) {
         const now = new Date();
         const yesterday = new Date();
         yesterday.setDate(yesterday - 1);
-        if(format(now, dateFormat) != format(endOfDay(now), dateFormat) || format(now, dateFormat) == format(yesterday, dateFormat)){
+        if(format(now, dateFormat) == format(yesterday, dateFormat)){
             if(self.verbose){
                 console.log(new Date(),"[FileStreamRotator] Changing type to custom as date format changes more often than once a day or not every day");
             }

--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -12,8 +12,9 @@
  */
 var fs = require('fs');
 var path = require('path');
-var moment = require('moment');
 var crypto = require('crypto');
+var {format, formatInTimeZone} = require('date-fns-tz');
+var { endOfDay } = require('date-fns');
 
 var EventEmitter = require('events');
 
@@ -27,11 +28,11 @@ var EventEmitter = require('events');
  *   - `filename`       Filename including full path used by the stream
  *
  *   - `frequency`      How often to rotate. Options are 'daily', 'custom' and 'test'. 'test' rotates every minute.
- *                      If frequency is set to none of the above, a YYYYMMDD string will be added to the end of the filename.
+ *                      If frequency is set to none of the above, a yyyyMMdd string will be added to the end of the filename.
  *
  *   - `verbose`        If set, it will log to STDOUT when it rotates files and name of log file. Default is TRUE.
  *
- *   - `date_format`    Format as used in moment.js http://momentjs.com/docs/#/displaying/format/. The result is used to replace
+ *   - `date_format`    Format as used in date-fns https://date-fns.org/v2.28.0/docs/format. The result is used to replace
  *                      the '%DATE%' placeholder in the filename.
  *                      If using 'custom' frequency, it is used to trigger file change when the string representation changes.
  *
@@ -75,7 +76,7 @@ var FileStreamRotator = {};
 module.exports = FileStreamRotator;
 
 var staticFrequency = ['daily', 'test', 'm', 'h', 'custom'];
-var DATE_FORMAT = ('YYYYMMDDHHmm');
+var DATE_FORMAT = ('yyyyMMddHHmm');
 
 
 /**
@@ -165,31 +166,34 @@ FileStreamRotator.parseFileSize = function (size) {
 
 /**
  * Returns date string for a given format / date_format
- * @param format
+ * @param formatOptions
  * @param date_format
  * @param {boolean} utc
  * @returns {string}
  */
-FileStreamRotator.getDate = function (format, date_format, utc) {
+FileStreamRotator.getDate = function (formatOptions, date_format, utc) {
     date_format = date_format || DATE_FORMAT;
-    let currentMoment = utc ? moment.utc() : moment().local()
-    if (format && staticFrequency.indexOf(format.type) !== -1) {
-        switch (format.type) {
+    let logDate = new Date();
+
+    if (formatOptions && staticFrequency.indexOf(formatOptions.type) !== -1) {
+        switch (formatOptions.type) {
             case 'm':
-                var minute = Math.floor(currentMoment.minutes() / format.digit) * format.digit;
-                return currentMoment.minutes(minute).format(date_format);
+                var minute = Math.floor(logDate.getMinutes() / formatOptions.digit) * formatOptions.digit;
+                logDate.setMinutes(minute);
                 break;
             case 'h':
-                var hour = Math.floor(currentMoment.hour() / format.digit) * format.digit;
-                return currentMoment.hour(hour).format(date_format);
+                var hour = Math.floor(logDate.getHours() / formatOptions.digit) * formatOptions.digit;
+                logDate.setHours(hour)
                 break;
             case 'daily':
             case 'custom':
             case 'test':
-                return currentMoment.format(date_format);
+                break;
         }
     }
-    return currentMoment.format(date_format);
+    if (utc)
+        return formatInTimeZone(logDate, 'Zulu', date_format);
+    return format(logDate, date_format);
 }
 
 /**
@@ -378,7 +382,8 @@ FileStreamRotator.addLogToAudit = function(logfile, audit, stream, verbose){
         });
 
         if(audit.keep.days){
-            var oldestDate = moment().subtract(audit.keep.amount,"days").valueOf();
+            let oldestDate = new Date();
+            oldestDate.setDate(oldestDate.getDate() - audit.keep.amount);
             var recentFiles = audit.files.filter(function(file){
                 if(file.date > oldestDate){
                     return true;
@@ -451,9 +456,12 @@ FileStreamRotator.getStream = function (options) {
     var dateFormat = (options.date_format || DATE_FORMAT);
     if(frequencyMetaData && frequencyMetaData.type == "daily"){
         if(!options.date_format){
-            dateFormat = "YYYY-MM-DD";
+            dateFormat = "yyyy-MM-dd";
         }
-        if(moment().format(dateFormat) != moment().endOf("day").format(dateFormat) || moment().format(dateFormat) == moment().add(1,"day").format(dateFormat)){
+        const now = new Date();
+        const yesterday = new Date();
+        yesterday.setDate(yesterday - 1);
+        if(format(now, dateFormat) != format(endOfDay(now), dateFormat) || format(now, dateFormat) == format(yesterday, dateFormat)){
             if(self.verbose){
                 console.log(new Date(),"[FileStreamRotator] Changing type to custom as date format changes more often than once a day or not every day");
             }
@@ -556,7 +564,7 @@ FileStreamRotator.getStream = function (options) {
             if(!options.watch_log){
                 return
             }
-            // console.log("ADDING WATCHER", newLog)
+            // console.log("AddING WATCHER", newLog)
             logWatcher = createLogWatcher(newLog, self.verbose, function(err,newLog){
                 stream.emit('createLog', newLog)
             })        

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install file-stream-rotator
 
  - *filename*:       Filename including full path used by the stream
  - *frequency*:      How often to rotate. Options are 'daily', 'custom' and 'test'. 'test' rotates every minute.
-                     If frequency is set to none of the above, a YYYYMMDD string will be added to the end of the filename.
+                     If frequency is set to none of the above, a yyyyMMdd string will be added to the end of the filename.
  - *verbose*:        If set, it will log to STDOUT when it rotates files and name of log file. Default is TRUE.
  - *date_format*:    Format as used in moment.js http://momentjs.com/docs/#/displaying/format/. The result is used to replace
                      the '%DATE%' placeholder in the filename.
@@ -50,16 +50,16 @@ npm install file-stream-rotator
     var rotatingLogStream = require('file-stream-rotator').getStream({filename:"/tmp/test-%DATE%.log", frequency:"daily", verbose: false});
  
     // Custom date added using file pattern using moment.js formats
-    var rotatingLogStream = require('file-stream-rotator').getStream({filename:"/tmp/test-%DATE%.log", frequency:"daily", verbose: false, date_format: "YYYY-MM-DD"});
+    var rotatingLogStream = require('file-stream-rotator').getStream({filename:"/tmp/test-%DATE%.log", frequency:"daily", verbose: false, date_format: "yyyy-MM-dd"});
  
     // Rotate when the date format as calculated by momentjs is different (e.g monthly)
-    var rotatingLogStream = require('file-stream-rotator').getStream({filename:"/tmp/test-%DATE%.log", frequency:"custom", verbose: false, date_format: "YYYY-MM"});
+    var rotatingLogStream = require('file-stream-rotator').getStream({filename:"/tmp/test-%DATE%.log", frequency:"custom", verbose: false, date_format: "yyyy-MM"});
  
     // Rotate when the date format as calculated by momentjs is different (e.g weekly)
-    var rotatingLogStream = require('file-stream-rotator').getStream({filename:"/tmp/test-%DATE%.log", frequency:"custom", verbose: false, date_format: "YYYY-ww"});
+    var rotatingLogStream = require('file-stream-rotator').getStream({filename:"/tmp/test-%DATE%.log", frequency:"custom", verbose: false, date_format: "yyyy-ww"});
  
     // Rotate when the date format as calculated by momentjs is different (e.g AM/PM)
-    var rotatingLogStream = require('file-stream-rotator').getStream({filename:"/tmp/test-%DATE%.log", frequency:"custom", verbose: false, date_format: "YYYY-MM-DD-A"});
+    var rotatingLogStream = require('file-stream-rotator').getStream({filename:"/tmp/test-%DATE%.log", frequency:"custom", verbose: false, date_format: "yyyy-MM-dd-A"});
  
     // Rotate on given minutes using the 'm' option i.e. 5m or 30m
     var rotatingLogStream = require('file-stream-rotator').getStream({filename:"/tmp/test.log", frequency:"5m", verbose: false});
@@ -111,7 +111,7 @@ You can also limit the size of each file by adding the size option using "k", "m
             filename:"/tmp/test-%DATE%.log", 
             frequency:"custom", 
             verbose: false, 
-            date_format: "YYYY-MM-DD",
+            date_format: "yyyy-MM-dd",
             size: "5M" // its letter denominating the size is case insensitive
         }
     );

--- a/date-fns-results.txt
+++ b/date-fns-results.txt
@@ -1,0 +1,35 @@
+
+> @zwave-js/file-stream-rotator@0.5.8-0 test
+> node test.js
+
+3k 3072 3072
+5M 5242880 5242880
+0.5G 536870912 536870912
+0.5T null null
+1mega null null
+10 giga null null
+obj = { type: 'm', digit: 5 }
+obj = { type: 'h', digit: 24 }
+obj = { type: 'h', digit: 23 }
+testGetDate
+202202111127
+202202111127
+202202111127
+202202111100
+202202111100
+202202110927
+202202111125
+20220211
+2022-02-11
+20220211.112747
+2022-02-11:11:27:47
+{
+  keep: { days: true, amount: 10 },
+  auditLog: '/tmp/a/b/c/files/.audit.json',
+  files: []
+}
+{
+  keep: { days: false, amount: 10 },
+  auditLog: '/tmp/a/b/log_audit_file.json',
+  files: []
+}

--- a/moment-results.txt
+++ b/moment-results.txt
@@ -1,0 +1,35 @@
+
+> @zwave-js/file-stream-rotator@0.5.8-0 test
+> node test.js
+
+3k 3072 3072
+5M 5242880 5242880
+0.5G 536870912 536870912
+0.5T null null
+1mega null null
+10 giga null null
+obj = { type: 'm', digit: 5 }
+obj = { type: 'h', digit: 24 }
+obj = { type: 'h', digit: 23 }
+testGetDate
+202202111107
+202202111107
+202202111107
+202202111100
+202202111100
+202202110907
+202202111105
+20220211
+2022-02-11
+20220211.110748
+2022-02-11:11:07:48
+{
+  keep: { days: true, amount: 10 },
+  auditLog: '/tmp/a/b/c/files/.audit.json',
+  files: []
+}
+{
+  keep: { days: false, amount: 10 },
+  auditLog: '/tmp/a/b/log_audit_file.json',
+  files: []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,50 @@
 {
     "name": "@zwave-js/file-stream-rotator",
     "version": "0.5.8-0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "name": "@zwave-js/file-stream-rotator",
+            "version": "0.5.8-0",
+            "license": "MIT",
+            "dependencies": {
+                "date-fns": "^2.28.0",
+                "date-fns-tz": "^1.2.2"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "2.28.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+            "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+            "engines": {
+                "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
+            }
+        },
+        "node_modules/date-fns-tz": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.2.2.tgz",
+            "integrity": "sha512-vWtn44eEqnLbkACb7T5G5gPgKR4nY8NkNMOCyoY49NsRGHrcDmY2aysCyzDeA+u+vcDBn/w6nQqEDyouRs4m8w==",
+            "peerDependencies": {
+                "date-fns": ">=2.0.0"
+            }
+        }
+    },
     "dependencies": {
-        "moment": {
-            "version": "2.29.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+        "date-fns": {
+            "version": "2.28.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+            "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+        },
+        "date-fns-tz": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.2.2.tgz",
+            "integrity": "sha512-vWtn44eEqnLbkACb7T5G5gPgKR4nY8NkNMOCyoY49NsRGHrcDmY2aysCyzDeA+u+vcDBn/w6nQqEDyouRs4m8w==",
+            "requires": {}
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "author": "Roger Castells",
     "license": "MIT",
     "dependencies": {
-        "date-fns": "^2.28.0",
         "date-fns-tz": "^1.2.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "author": "Roger Castells",
     "license": "MIT",
     "dependencies": {
-        "moment": "^2.11.2"
+        "date-fns": "^2.28.0",
+        "date-fns-tz": "^1.2.2"
     }
 }

--- a/test.js
+++ b/test.js
@@ -108,11 +108,12 @@ var tests = {
         var opt5 = {type: 'h', digit: 3};
         var opt6 = {type: 'm', digit: 5};
 
-        var format1 = 'YYYYMMDD';
-        var format2 = 'YYYY-MM-DD';
-        var format3 = 'YYYYMMDD.HHmmss';
-        var format4 = 'YYYY-MM-DD:HH:mm:ss';
+        var format1 = 'yyyyMMdd';
+        var format2 = 'yyyy-MM-dd';
+        var format3 = 'yyyyMMdd.HHmmss';
+        var format4 = 'yyyy-MM-dd:HH:mm:ss';
 
+        console.log('testGetDate');
         console.log(fsr.getDate(opt));
         console.log(fsr.getDate(opt1));
         console.log(fsr.getDate(opt2));
@@ -151,10 +152,10 @@ var tests = {
 
         var test = function() {
 
-            var options1 = { filename: logdir + 'program1.log', frequency: '1m', verbose: true, date_format: 'YYYY-MM-DD' };
+            var options1 = { filename: logdir + 'program1.log', frequency: '1m', verbose: true, date_format: 'yyyy-MM-dd' };
             var options2 = { filename: logdir + 'program2.log', frequency: '1m', verbose: true};
-            var options3 = { filename: logdir + 'program3-%DATE%.log', frequency: '1m', verbose: true, date_format: 'YYYY-MM-DD'};
-            var options4 = { filename: logdir + 'program4-%DATE%.log', verbose: true, date_format: 'YYYY-MM-DD'};
+            var options3 = { filename: logdir + 'program3-%DATE%.log', frequency: '1m', verbose: true, date_format: 'yyyy-MM-dd'};
+            var options4 = { filename: logdir + 'program4-%DATE%.log', verbose: true, date_format: 'yyyy-MM-dd'};
             var options5 = { filename: logdir + 'program5-%DATE%.log', verbose: true};
 
             var stream1 = fsr.getStream(options1);
@@ -169,7 +170,7 @@ var tests = {
             stream5.write('dafault date mid filename without rotation');
 
 
-            var options = { filename: logdir + 'program-%DATE%.log', frequency: '1m', verbose: true, date_format: 'YYYY-MM-DD:HH:mm' };
+            var options = { filename: logdir + 'program-%DATE%.log', frequency: '1m', verbose: true, date_format: 'yyyy-MM-dd:HH:mm' };
 
             var stream = fsr.getStream(options);
             process.__defineGetter__('stdout', function() { return stream;});

--- a/tests/every-minute-test.js
+++ b/tests/every-minute-test.js
@@ -1,14 +1,14 @@
 var moment = require('moment');
 // var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"1m", verbose: true});
-// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"custom", verbose: true, date_format: "YYYY-MM-DD.HH.mm"});
-// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"dont-rotate", verbose: true, date_format: "YYYY-MM-DD.HH.mm.ss"});
-// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"daily", verbose: true, date_format: "YYYYMMDD"});
+// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"custom", verbose: true, date_format: "yyyy-MM-dd.HH.mm"});
+// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"dont-rotate", verbose: true, date_format: "yyyy-MM-dd.HH.mm.ss"});
+// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"daily", verbose: true, date_format: "yyyyMMdd"});
 // var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"daily", verbose: true});
 var rotatingLogStream = require('../FileStreamRotator').getStream({
     filename: "logs/1m/testlog-%DATE%", 
     frequency: "1m", 
     verbose: true, 
-    date_format: "YYYY-MM-DD.HH.mm", 
+    date_format: "yyyy-MM-dd.HH.mm", 
     size: "500k", 
     max_logs: "10",
     audit_file: "/tmp/audit.json",
@@ -55,7 +55,7 @@ rotatingLogStream.on("logRemoved", function (newFile) {
 //     filename: "/tmp/a/logs/1m-1/testlog-%DATE%.log", 
 //     frequency: "1m", 
 //     verbose: true, 
-//     date_format: "YYYY-MM-DD.HH.mm", 
+//     date_format: "yyyy-MM-dd.HH.mm", 
 //     size: "50k", 
 //     max_logs: "10",
 //     audit_file: "/tmp/audit-1.json",

--- a/tests/every-second-test.js
+++ b/tests/every-second-test.js
@@ -1,14 +1,14 @@
 var moment = require('moment');
 // var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"1m", verbose: true});
-// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"custom", verbose: true, date_format: "YYYY-MM-DD.HH.mm"});
-// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"dont-rotate", verbose: true, date_format: "YYYY-MM-DD.HH.mm.ss"});
-// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"daily", verbose: true, date_format: "YYYYMMDD"});
+// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"custom", verbose: true, date_format: "yyyy-MM-dd.HH.mm"});
+// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"dont-rotate", verbose: true, date_format: "yyyy-MM-dd.HH.mm.ss"});
+// var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"daily", verbose: true, date_format: "yyyyMMdd"});
 // var rotatingLogStream = require('../FileStreamRotator').getStream({filename:"/tmp/testlog-%DATE%.log", frequency:"daily", verbose: true});
 var rotatingLogStream = require('../FileStreamRotator').getStream({
     filename:"logs/1s/testlog-%DATE%.log", 
     frequency:"custom", 
     verbose: true, 
-    date_format: "YYYY-MM-DD.HH.mm", 
+    date_format: "yyyy-MM-dd.HH.mm", 
     size:"50k",
     max_logs: "5", 
     audit_file:"audit-1s.json",


### PR DESCRIPTION
I'm using this is a very low memory environment, and moment js is roughly half the code/memory footprint of **all of zwave-js**. Switching to date-fns-tz dropped the size and memory footprint considerably.

Moment has been subsetted due to incompatibility with tree shaking.